### PR TITLE
.github: only bump v2 tag in workflow

### DIFF
--- a/.github/workflows/bump-cache-version.yml
+++ b/.github/workflows/bump-cache-version.yml
@@ -37,12 +37,13 @@ jobs:
           git commit -m "Bump @actions/cache version to ${{ github.event.inputs.cache_version }}"
           git push origin main
     
-      - name: Update v1 tag
+      # NOTE: DO NOT bump v1, since we want to keep it backed by the Blacksmith cache for now.
+      - name: Update v2 tag
         if: steps.git-check.outputs.changes == 'true'
         run: |
           git fetch --all --tags
-          git tag -fa v1 -m "Update v1 tag to latest commit"
-          git push origin v1 --force
+          git tag -fa v2 -m "Update v2 tag to latest commit"
+          git push origin v2 --force
     
     
       - name: Send Slack notification on success
@@ -51,7 +52,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Bumped setup-bazel v1 to the HEAD of main that points to ${{ github.event.inputs.cache_version }}"
+              "text": "Bumped setup-bazel v2 to the HEAD of main that points to ${{ github.event.inputs.cache_version }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CACHE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify workflow to update only the v2 tag and adjust Slack notification accordingly.
> 
>   - **Workflow Changes**:
>     - Modify `.github/workflows/bump-cache-version.yml` to update only the `v2` tag instead of `v1`.
>     - Add a comment explaining that `v1` should not be bumped to keep it backed by the Blacksmith cache.
>   - **Notifications**:
>     - Update Slack notification message to indicate `v2` tag update instead of `v1`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fsetup-bazel&utm_source=github&utm_medium=referral)<sup> for 880868329500ec4f1953ce612670e24a597db233. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->