### PR TITLE
.github: fix bumping workflows

### DIFF
--- a/.github/workflows/bump-cache-version.yml
+++ b/.github/workflows/bump-cache-version.yml
@@ -37,13 +37,13 @@ jobs:
           git commit -m "Bump @actions/cache version to ${{ github.event.inputs.cache_version }}"
           git push origin main
     
-      # NOTE: DO NOT bump v1, since we want to keep it backed by the Blacksmith cache for now.
-      - name: Update v2 tag
+      # NOTE: Only bump v1, since we want to keep it backed by the Blacksmith cache for now.
+      - name: Update v1 tag
         if: steps.git-check.outputs.changes == 'true'
         run: |
           git fetch --all --tags
-          git tag -fa v2 -m "Update v2 tag to latest commit"
-          git push origin v2 --force
+          git tag -fa v1 -m "Update v1 tag to latest commit"
+          git push origin v1 --force
     
     
       - name: Send Slack notification on success
@@ -52,7 +52,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Bumped setup-bazel v2 to the HEAD of main that points to ${{ github.event.inputs.cache_version }}"
+              "text": "Bumped setup-bazel v1 to the HEAD of main that points to ${{ github.event.inputs.cache_version }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.CACHE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/bump-tag.yml
+++ b/.github/workflows/bump-tag.yml
@@ -1,0 +1,28 @@
+name: Bump Tag
+
+on:
+  workflow_dispatch:
+
+jobs:
+  bump-cache-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # NOTE: Only bump v2, since we want to keep v1 backed by the Blacksmith cache for now.
+      - name: Update v2 tag
+        run: |
+          git fetch --all --tags
+          git tag -fa v2 -m "Update v2 tag to latest commit"
+          git push origin v2 --force
+    
+    
+      - name: Send Slack notification on success
+        uses: slackapi/slack-github-action@v1
+        with:
+          payload: |
+            {
+              "text": "Bumped setup-bazel v2 to the HEAD of main"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.CACHE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust GitHub workflows to update `v1` and `v2` tags separately, ensuring `v1` remains backed by Blacksmith cache.
> 
>   - **Workflows**:
>     - In `bump-cache-version.yml`, change tag update from `v2` to `v1` to keep `v1` backed by Blacksmith cache.
>     - Add new workflow `bump-tag.yml` to update `v2` tag independently.
>   - **Notifications**:
>     - Update Slack notification in `bump-cache-version.yml` to reflect `v1` tag update.
>     - Add Slack notification in `bump-tag.yml` for `v2` tag update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=useblacksmith%2Fsetup-bazel&utm_source=github&utm_medium=referral)<sup> for b4a0a5a4c643c959940e041179f82b1ebb17e8b6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->