### PR TITLE
Bump Snyk-flagged dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,17 +14,17 @@
   "license": "MIT",
   "dependencies": {
     "@actions/cache": "npm:@useblacksmith/cache@3.2.213",
-    "@actions/core": "^1.10.1",
-    "@actions/github": "^6.0.0",
+    "@actions/core": "^1.11.1",
+    "@actions/github": "^6.0.1",
     "@actions/glob": "^0.5.0",
-    "@actions/tool-cache": "^2.0.1",
+    "@actions/tool-cache": "^2.0.2",
     "@buf/blacksmith_vm-agent.bufbuild_es": "1.5.0-20251002224722-c44b45f26c5e.2",
     "@buf/blacksmith_vm-agent.connectrpc_es": "1.6.1-20251002224722-c44b45f26c5e.2",
     "@bufbuild/protobuf": "^1.4.2",
     "@connectrpc/connect": "^1.6.1",
     "@connectrpc/connect-node": "^1.6.1",
     "@vercel/ncc": "^0.38.3",
-    "yaml": "^2.2.1"
+    "yaml": "^2.8.0"
   },
   "devDependencies": {
     "jest": "^29.7.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@bufbuild/protobuf": "^1.4.2",
     "@connectrpc/connect": "^1.6.1",
     "@connectrpc/connect-node": "^1.6.1",
-    "@vercel/ncc": "^0.38.0",
+    "@vercel/ncc": "^0.38.3",
     "yaml": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Consolidates 5 open Snyk upgrade PRs (#16, #17, #18, #19, #20) into a single PR by bumping the minimum versions in package.json.

**How it works:**
- `@actions/core` ^1.10.1 → ^1.11.1
- `@actions/github` ^6.0.0 → ^6.0.1
- `@actions/tool-cache` ^2.0.1 → ^2.0.2
- `@vercel/ncc` ^0.38.0 → ^0.38.3
- `yaml` ^2.2.1 → ^2.8.0

The three `@actions/cache` Snyk PRs (#15, #21, #23) were intentionally excluded — they would replace the `@useblacksmith/cache` fork with the official `@actions/cache`, breaking the Blacksmith integration. The lockfile and dist/ will be regenerated in CI once the BUF_TOKEN is available for the private registry.

---
[View Codesmith session](https://staging.blacksmith.sh/useblacksmith/sessions/019d2b19-16a1-70f3-a69c-801b7787e164)